### PR TITLE
Confluence attachments: add configurable size/char thresholds

### DIFF
--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -609,7 +609,24 @@ export const connectorConfigs: Record<
         defaultTab: "space",
       },
     ],
-    advanced_values: [],
+    advanced_values: [
+      {
+        type: "number",
+        label: "Attachment Size Threshold (bytes)",
+        name: "attachment_size_threshold_bytes",
+        optional: true,
+        description:
+          "Attachments larger than this will be skipped. Leave blank to use default (10 MB).",
+      },
+      {
+        type: "number",
+        label: "Attachment Text Character Threshold",
+        name: "attachment_char_count_threshold",
+        optional: true,
+        description:
+          "If extracted text exceeds this character limit, the attachment is skipped. Leave blank to use default (200,000).",
+      },
+    ],
   },
   jira: {
     description: "Configure Jira connector",


### PR DESCRIPTION
## Description
This PR adds configurable parameters under advanced settings for Confluence allowing customization of the file size/char count limit thresholds. Today this is managed via the global env vars ` CONFLUENCE_MAX_ATTACHMENT_SIZE` and `CONFLUENCE_CONNECTOR_ATTACHMENT_CHAR_COUNT_THRESHOLD` , however a global value is not adequate for all use cases that require different threshold levels.
