### PR TITLE
chat: do not persist 'Cancelled' as assistant message on cancellation

### DIFF
--- a/backend/onyx/chat/turn/fast_chat_turn.py
+++ b/backend/onyx/chat/turn/fast_chat_turn.py
@@ -164,7 +164,7 @@ def _emit_clean_up_packets(
             Packet(
                 ind=ctx.current_run_step,
                 obj=MessageStart(
-                    type="message_start", content="Cancelled", final_documents=None
+                    type="message_start", content="", final_documents=None
                 ),
             )
         )


### PR DESCRIPTION
Summary
When a user cancels or disconnects mid-generation, the cleanup path emitted a MessageStart with content="Cancelled". The session sink concatenates packet contents into the final_answer, causing "Cancelled" to be saved as the assistant reply. This change emits an empty string instead, preserving packet structure while preventing misleading content from being stored.

Bug
- Path: fast_chat_turn._emit_clean_up_packets -> session_sink.extract_final_answer_from_packets -> save_iteration
- Before: cleanup emits MessageStart(content="Cancelled"), which becomes the stored reply
- After: cleanup emits MessageStart(content="") so cancelled messages don't show incorrect text

Impact
- Users saw a literal "Cancelled" answer; confusing UX on a common flow.

Repro
- Start a chat, trigger streaming, cancel mid-stream. Observe saved message content.

Fix
- Minimal one-line change in fast_chat_turn.py: "Cancelled" -> "" on cleanup MessageStart emission.

Areas touched
- backend/onyx/chat/turn/fast_chat_turn.py