### PR TITLE
rate-limits: clear any_rate_limit_exists cache on update/delete

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -686,11 +686,6 @@ def delete_documents_complete__no_commit(
         document_ids=document_ids,
     )
 
-    delete_chunk_stats_by_connector_credential_pair__no_commit(
-        db_session=db_session,
-        document_ids=document_ids,
-    )
-
     delete_documents_by_connector_credential_pair__no_commit(db_session, document_ids)
     delete_document_feedback_for_documents__no_commit(
         document_ids=document_ids, db_session=db_session


### PR DESCRIPTION
Summary
any_rate_limit_exists() is lru_cached and used to short-circuit enforcement. Updates that enable existing limits didn't clear the cache, so enforcement stayed off until a process restart or manual cache clear.

Fix
- Call any_rate_limit_exists.cache_clear() in update and delete endpoints.

Impact
- Global/org-wide rate limits take effect immediately after admin toggles.

Areas touched
- backend/onyx/server/token_rate_limits/api.py