### PR TITLE
concurrency: ThreadSafeDict.items() returns snapshot to avoid KeyError

### DIFF
--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -134,10 +134,12 @@ class ThreadSafeDict(MutableMapping[KT, VT]):
         with self.lock:
             self._dict.update(*args, **kwargs)
 
-    def items(self) -> collections.abc.ItemsView[KT, VT]:
-        """Return a view of (key, value) pairs atomically."""
+    def items(self) -> list[tuple[KT, VT]]:
+        """Return a snapshot list of (key, value) pairs atomically.
+        This avoids KeyError crashes if the dict is mutated during iteration.
+        """
         with self.lock:
-            return collections.abc.ItemsView(self)
+            return list(self._dict.items())
 
     def keys(self) -> collections.abc.KeysView[KT]:
         """Return a view of keys atomically."""


### PR DESCRIPTION
Summary
ThreadSafeDict.items() returned a live ItemsView causing KeyError during iteration when mutated concurrently. Return a snapshot list of pairs instead.

Impact
- Prevents crashes in connectors relying on items() in multi-threaded loops (e.g., Google Drive).

Areas touched
- backend/onyx/utils/threadpool_concurrency.py